### PR TITLE
pep8 is deprecated, pycodestyle should be used instead

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@
 coverage
 sphinx
 pylint
-pep8
+pycodestyle
 django-debug-toolbar
 django-extensions
 tox


### PR DESCRIPTION
When you use pep8, you get this deprecation message.
So, I replaced pep8 by pycodestyle in `requirements/dev.txt`.

Beware the CRLF (Dos) > LF (Unix) conversion I did out of habit, that may not be what you want.