### PR TITLE
Use Pathlib in settings

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -1,13 +1,13 @@
-from os.path import abspath, basename, dirname, join, normpath
+from pathlib import Path
 
 
 ######################
 # Path configuration #
 ######################
 
-DJANGO_ROOT = dirname(dirname(abspath(__file__)))
-SITE_ROOT = dirname(DJANGO_ROOT)
-SITE_NAME = basename(DJANGO_ROOT)
+DJANGO_ROOT = Path(__file__).resolve(strict=True).parent.parent
+SITE_ROOT = DJANGO_ROOT.parent
+SITE_NAME = DJANGO_ROOT.name
 
 
 #######################
@@ -99,7 +99,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 #######################
 
 LOCALE_PATHS = [
-    normpath(join(DJANGO_ROOT, 'locale')),
+    DJANGO_ROOT / 'locale'
 ]
 
 
@@ -109,7 +109,7 @@ LOCALE_PATHS = [
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/var/www/example.com/media/"
-MEDIA_ROOT = normpath(join(DJANGO_ROOT, 'media'))
+MEDIA_ROOT = DJANGO_ROOT / 'media'
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
@@ -125,7 +125,7 @@ MEDIA_URL = '/media/'
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
-STATIC_ROOT = normpath(join(SITE_ROOT, 'assets'))
+STATIC_ROOT = SITE_ROOT / 'assets'
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
@@ -133,7 +133,7 @@ STATIC_URL = '/site_media/'
 
 # Additional locations of static files
 STATICFILES_DIRS = [
-    normpath(join(DJANGO_ROOT, 'static')),
+    DJANGO_ROOT / 'static',
 ]
 
 # List of finder classes that know how to find static files in

--- a/project_name/settings/dev.py
+++ b/project_name/settings/dev.py
@@ -1,5 +1,5 @@
 from os import environ
-from os.path import normpath
+from pathlib import Path
 
 from .base import *
 
@@ -47,7 +47,10 @@ ALLOWED_HOSTS = ['*']
 # Log configuration #
 #####################
 
-LOGGING['handlers']['file']['filename'] = environ.get('LOG_DIR', normpath(join('/tmp', '%s.log' % SITE_NAME)))
+LOGGING['handlers']['file']['filename'] = environ.get(
+    'LOG_DIR',
+    Path('/tmp').resolve(strict=True) / f'{SITE_NAME}.log',
+)
 LOGGING['handlers']['file']['level'] = 'DEBUG'
 
 for logger in LOGGING['loggers']:

--- a/project_name/settings/unittest.py
+++ b/project_name/settings/unittest.py
@@ -1,5 +1,6 @@
 from os import environ
-from os.path import normpath
+from pathlib import Path
+
 from .base import *
 
 #######################
@@ -34,7 +35,10 @@ ALLOWED_HOSTS = ['*']
 # Log configuration #
 #####################
 
-LOGGING['handlers']['file']['filename'] = environ.get('LOG_DIR', normpath(join('/tmp', 'test_%s.log' % SITE_NAME)))
+LOGGING['handlers']['file']['filename'] = environ.get(
+    'LOG_DIR',
+    Path('/tmp').resolve(strict=True) / f'test_{SITE_NAME}.log',
+)
 LOGGING['handlers']['file']['level'] = 'DEBUG'
 
 for logger in LOGGING['loggers']:


### PR DESCRIPTION
Django 3.1 uses pathlib to define the BASE_DIR setting.

pathlib is much easier to use than os.path. It was added to Python 3.4 and all file path using functions were enhanced to support pathlib in Python 3.6.

See [Use Pathlib in Your Django Settings File](https://adamj.eu/tech/2020/03/16/use-pathlib-in-your-django-project/) for more on this change.